### PR TITLE
[HTD-25] Feat: add `Navigation content sidebar links`

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,6 +34,7 @@ import { FluidCard } from '@/components/modules/fluid-card';
 import { HeadingBlock } from '@/components/modules/heading-block';
 import { Input } from '@/components/modules/input';
 import { IntegrationCard } from '@/components/modules/integration-card';
+import { NavigationSidebarLinks } from '@/components/modules/navigation-sidebar-links';
 import { TableContent } from '@/components/modules/table-content';
 import { CTA } from '@/components/sections/cta';
 import BlogPostImage from '@/content/posts/analytics-map.png';
@@ -108,6 +109,39 @@ export default async function Home() {
       subItems: [
         {
           text: 'Information automatically collected',
+          href: '#example',
+        },
+      ],
+    },
+  ];
+
+  const navigationContentSidebar = [
+    {
+      text: 'Payments processing',
+      subitems: [
+        {
+          text: 'Standard checkout',
+          href: '#example',
+        },
+        {
+          text: 'Internet transfer',
+          href: '#example',
+        },
+      ],
+    },
+    {
+      text: 'How to pay?',
+      href: '#example',
+    },
+    {
+      text: 'Troubles with payment',
+      subitems: [
+        {
+          text: 'How to find your money',
+          href: '#example',
+        },
+        {
+          text: 'My money has gone',
           href: '#example',
         },
       ],
@@ -439,6 +473,9 @@ export default async function Home() {
   { timeout: 2000 }
 );`}
           />
+        </ShowCase>
+        <ShowCase title="Navigation content sidebar links">
+          <NavigationSidebarLinks title="On this page" links={navigationContentSidebar} />
         </ShowCase>
         <ShowCase title="Simple Footer">
           <SimpleFooter />

--- a/src/components/modules/navigation-sidebar-links/index.tsx
+++ b/src/components/modules/navigation-sidebar-links/index.tsx
@@ -1,0 +1,45 @@
+import {
+  StyledNavigationSidebarLinksContentItem,
+  StyledNavigationSidebarLinksContentLink,
+  StyledNavigationSidebarLinksContentTitle,
+  StyledNavigationSidebarLinksContentWrapper,
+  StyledNavigationSidebarLinksTitle,
+  StyledNavigationSidebarLinksWrapper,
+} from './navigation-sidebar-links.styles';
+import type { NavigationSidebarLinkItem, NavigationSidebarLinksProps } from './navigation-sidebar-links.types';
+
+import { Link } from '@/components/elements/link';
+
+const ItemTitleComponent = ({ text, href }: NavigationSidebarLinkItem) => {
+  if (href) {
+    return <Link href={href}>{text}</Link>;
+  }
+
+  return text;
+};
+
+export const NavigationSidebarLinks = ({ title, links }: NavigationSidebarLinksProps) => {
+  return (
+    <StyledNavigationSidebarLinksWrapper>
+      <StyledNavigationSidebarLinksTitle forwardedAs="p" fontSize="xs" fontWeight="medium" color="white">
+        {title}
+      </StyledNavigationSidebarLinksTitle>
+      <StyledNavigationSidebarLinksContentWrapper>
+        {Array.isArray(links) &&
+          links.map(link => (
+            <StyledNavigationSidebarLinksContentItem>
+              <StyledNavigationSidebarLinksContentTitle fontSize="m" fontWeight="bold" color="white">
+                <ItemTitleComponent {...link} />
+              </StyledNavigationSidebarLinksContentTitle>
+              {Array.isArray(link.subitems) &&
+                link.subitems.map(link => (
+                  <StyledNavigationSidebarLinksContentLink href={link.href}>
+                    {link.text}
+                  </StyledNavigationSidebarLinksContentLink>
+                ))}
+            </StyledNavigationSidebarLinksContentItem>
+          ))}
+      </StyledNavigationSidebarLinksContentWrapper>
+    </StyledNavigationSidebarLinksWrapper>
+  );
+};

--- a/src/components/modules/navigation-sidebar-links/index.tsx
+++ b/src/components/modules/navigation-sidebar-links/index.tsx
@@ -32,6 +32,7 @@ export const NavigationSidebarLinks = ({ title, links }: NavigationSidebarLinksP
                 <ItemTitleComponent {...link} />
               </StyledNavigationSidebarLinksContentTitle>
               {Array.isArray(link.subitems) &&
+                link.subitems?.length > 0 &&
                 link.subitems.map(link => (
                   <StyledNavigationSidebarLinksContentLink href={link.href}>
                     {link.text}

--- a/src/components/modules/navigation-sidebar-links/index.tsx
+++ b/src/components/modules/navigation-sidebar-links/index.tsx
@@ -26,6 +26,7 @@ export const NavigationSidebarLinks = ({ title, links }: NavigationSidebarLinksP
       </StyledNavigationSidebarLinksTitle>
       <StyledNavigationSidebarLinksContentWrapper>
         {Array.isArray(links) &&
+          links?.length > 0 &&
           links.map(link => (
             <StyledNavigationSidebarLinksContentItem>
               <StyledNavigationSidebarLinksContentTitle fontSize="m" fontWeight="bold" color="white">

--- a/src/components/modules/navigation-sidebar-links/navigation-sidebar-links.styles.ts
+++ b/src/components/modules/navigation-sidebar-links/navigation-sidebar-links.styles.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { Heading } from '@/components/elements/heading';
+import { Link } from '@/components/elements/link';
+import { Text } from '@/components/elements/text';
+import { styled } from '@/styles';
+
+export const StyledNavigationSidebarLinksWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 8px 0;
+`;
+
+export const StyledNavigationSidebarLinksTitle = styled(Heading)``;
+
+export const StyledNavigationSidebarLinksContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+export const StyledNavigationSidebarLinksContentItem = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const StyledNavigationSidebarLinksContentTitle = styled(Text)`
+  display: inline-block;
+  padding: 8px 16px;
+`;
+
+export const StyledNavigationSidebarLinksContentLink = styled(Link)`
+  display: inline-block;
+  font-size: ${({ theme }) => theme.fontSizes.text.m};
+  line-height: 1.5;
+  color: ${({ theme }) => theme.colors.text.lightGrey};
+  padding: 8px 32px;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.text.white};
+  }
+`;

--- a/src/components/modules/navigation-sidebar-links/navigation-sidebar-links.types.ts
+++ b/src/components/modules/navigation-sidebar-links/navigation-sidebar-links.types.ts
@@ -1,0 +1,15 @@
+export interface NavigationSidebarLinkSubitem {
+  text: string;
+  href: string;
+}
+
+export interface NavigationSidebarLinkItem {
+  text: string;
+  href?: string;
+  subitems?: NavigationSidebarLinkSubitem[];
+}
+
+export interface NavigationSidebarLinksProps {
+  title: string;
+  links: NavigationSidebarLinkItem[];
+}


### PR DESCRIPTION
## Pull Request Description

<!-- Give an explanation of the changes introduced in this PR -->
<!-- Help other developers understood why it is done that way, how it works and why do you think that is the best way of doing it at the moment -->

## Assets

<!-- For UI work, put a screenshot confirming the quality of the work -->
<!-- It might be a PixelPerfect overlapping screenshot -->
<!-- or it might be a before/after screenshot, if you are not using PixelPerfect tool -->

| Light | Dark |
| ------ | ----- |
|    ![image](https://github.com/bejamas/httptoolkit-website/assets/58434305/e1cccb25-eb48-4120-b6a4-8f537118283c)    |    ![image](https://github.com/bejamas/httptoolkit-website/assets/58434305/959b3591-ce40-4d82-bca8-46839cf15a47)   |

## Before Merge Checklist

The following steps were checked before merging a PR

- [x] checked and fixed code style issues
- [x] checked and removed unnecessary/junky code
- [x] manually tested introduced solution
- [ ] added needed tests to automate testing this code in the future
